### PR TITLE
Update TFT_eSPI to 2.5.34

### DIFF
--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -51,7 +51,7 @@ build_flags =
 lib_deps = 
 	bblanchon/ArduinoJson@6.21.3
 	bitbank2/AnimatedGIF@^1.4.7
-	bodmer/TFT_eSPI@2.5.33
+	bodmer/TFT_eSPI@2.5.34
 
 extra_scripts = 
 	pre:scripts/generate_images.py


### PR DESCRIPTION
Tested locally for a few days haven't hit any issues yet, newer versions are showing as incompatible will try and find some time to investigate.